### PR TITLE
Add an executable that prints beats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,43 @@
+extern crate beats;
+
+use beats::Beat;
+
+const NAME: &str = env!("CARGO_PKG_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+const AUTHORS: &str = env!("CARGO_PKG_AUTHORS");
+const REPOSITORY: &str = env!("CARGO_PKG_REPOSITORY");
+
+
+fn print_usage() {
+    print!(r#"{} {}
+{}
+
+Prints the current system time in .beat / Swatch Internet time:
+https://en.wikipedia.org/wiki/Swatch_Internet_Time
+
+Project homepage: {}
+
+USAGE:
+    beats [-h]
+"#,
+        NAME, VERSION, AUTHORS, REPOSITORY
+);
+
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() <= 1 {
+        let beat = Beat::now();
+        println!("{}", beat);
+    } else if args[1] == "-h" {
+        print_usage();
+        std::process::exit(0);
+    } else {
+        eprintln!("Invalid arguments");
+        print_usage();
+        std::process::exit(1);
+    }
+}
+
+


### PR DESCRIPTION
This commit adds an executable to the package that prints the current
system time in beats and then exits.

The binary takes no arguments (there aren't many options with .beats
time, which is sort of it's beauty 🙂), but will print a usage message
and exit if any are passed. It exits with exit code 0 if run as `beats
-h` or with exit code 1 otherwise.